### PR TITLE
Normalize ten-digit recipients in SMS test command

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -829,6 +829,10 @@ Artisan::command('sms:test {to} {--message=}', function (SmsNotificationService 
         return 1;
     }
 
+    if (preg_match('/^\d{10}$/', $to)) {
+        $to = '+1'.$to;
+    }
+
     if (! preg_match('/^\+[1-9]\d{7,14}$/', $to)) {
         $this->error('Numero invalide. Utilisez le format E.164, ex: +15145551234');
 

--- a/tests/Feature/SmsTestCommandTest.php
+++ b/tests/Feature/SmsTestCommandTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    Http::preventStrayRequests();
+
+    config()->set('services.twilio.sid', 'AC_TEST_ACCOUNT_SID');
+    config()->set('services.twilio.token', 'test-auth-token');
+    config()->set('services.twilio.from', '+15145550101');
+});
+
+test('sms test command normalizes a ten digit north american recipient', function () {
+    Http::fake([
+        'https://api.twilio.com/*' => Http::response(['sid' => 'SM_TEST_MESSAGE_SID'], 201),
+    ]);
+
+    $this->artisan('sms:test', [
+        'to' => '5145550102',
+        '--message' => 'Rotation canary',
+    ])->assertExitCode(0);
+
+    Http::assertSent(fn (Request $request): bool => $request->data() === [
+        'To' => '+15145550102',
+        'From' => '+15145550101',
+        'Body' => 'Rotation canary',
+    ]);
+    Http::assertSentCount(1);
+});
+
+test('sms test command preserves an e164 recipient', function () {
+    Http::fake([
+        'https://api.twilio.com/*' => Http::response(['sid' => 'SM_TEST_MESSAGE_SID'], 201),
+    ]);
+
+    $this->artisan('sms:test', [
+        'to' => '+442079460123',
+        '--message' => 'International canary',
+    ])->assertExitCode(0);
+
+    Http::assertSent(fn (Request $request): bool => $request->data()['To'] === '+442079460123');
+    Http::assertSentCount(1);
+});
+
+test('sms test command rejects an invalid recipient without sending', function () {
+    Http::fake();
+
+    $this->artisan('sms:test', [
+        'to' => '51455',
+        '--message' => 'Invalid canary',
+    ])
+        ->expectsOutputToContain('Numero invalide')
+        ->assertExitCode(1);
+
+    Http::assertNothingSent();
+});
+
+test('sms test command refuses incomplete configuration without sending', function () {
+    config()->set('services.twilio.token');
+    Http::fake();
+
+    $this->artisan('sms:test', [
+        'to' => '+15145550102',
+        '--message' => 'Missing configuration canary',
+    ])
+        ->expectsOutputToContain('Configuration Twilio incomplete')
+        ->assertExitCode(1);
+
+    Http::assertNothingSent();
+});
+
+test('sms test command reports a provider rejection', function () {
+    Http::fake([
+        'https://api.twilio.com/*' => Http::response([
+            'code' => 20003,
+            'message' => 'Authentication Error - No credentials provided',
+            'more_info' => 'https://www.twilio.com/docs/errors/20003',
+        ], 401),
+    ]);
+
+    $this->artisan('sms:test', [
+        'to' => '5145550102',
+        '--message' => 'Rejected canary',
+    ])
+        ->expectsOutputToContain('reason=twilio_error status=401 code=20003')
+        ->assertExitCode(1);
+
+    Http::assertSentCount(1);
+});


### PR DESCRIPTION
## Summary

- normalize a 10-digit North American recipient to E.164 by adding `+1` in `sms:test`
- keep existing international E.164 recipients unchanged
- preserve strict validation for every other unsupported format
- add isolated command tests with fake Twilio responses and blocked stray HTTP requests

## Why

The operational canary used a common 10-digit Canadian number. The underlying SMS service can normalize that format, but the Artisan command rejected it before the service was called.

## Impact

This is limited to the `sms:test` operator command. Application notification workflows and the Twilio service contract are unchanged. No real SMS was sent by the automated tests.

## Validation

- targeted Twilio/command tests: 12 passed, 38 assertions
- functional regression selection: 74 passed, 444 assertions
- full PHP suite: 1,131 passed, 12,007 assertions
- Laravel Pint: 2 files pass
- `git diff --check`: pass