### PR TITLE
Add controlled Twilio canary safeguards

### DIFF
--- a/app/Services/WhatsappNotificationService.php
+++ b/app/Services/WhatsappNotificationService.php
@@ -8,35 +8,91 @@ class WhatsappNotificationService
 {
     public function send(string $to, string $message): bool
     {
-        $sid = config('services.twilio.sid');
-        $token = config('services.twilio.token');
-        $from = config('services.twilio.whatsapp_from');
+        $result = $this->sendWithResult($to, $message);
 
-        if (!$sid || !$token || !$from) {
-            return false;
-        }
-
-        $to = $this->normalizeWhatsappNumber($to);
-        $from = $this->normalizeWhatsappNumber($from);
-
-        $response = Http::withBasicAuth($sid, $token)
-            ->asForm()
-            ->post("https://api.twilio.com/2010-04-01/Accounts/{$sid}/Messages.json", [
-                'To' => $to,
-                'From' => $from,
-                'Body' => $message,
-            ]);
-
-        return $response->successful();
+        return (bool) ($result['ok'] ?? false);
     }
 
-    private function normalizeWhatsappNumber(string $value): string
+    public function sendWithResult(string $to, string $message): array
     {
-        $value = trim($value);
-        if ($value === '') {
-            return '';
+        $sid = trim((string) config('services.twilio.sid'));
+        $token = trim((string) config('services.twilio.token'));
+        $from = trim((string) config('services.twilio.whatsapp_from'));
+
+        if ($sid === '' || $token === '' || $from === '') {
+            return [
+                'ok' => false,
+                'reason' => 'missing_config',
+            ];
         }
 
-        return str_starts_with($value, 'whatsapp:') ? $value : 'whatsapp:' . $value;
+        $recipient = $this->normalizeWhatsappNumber($to);
+        $sender = $this->normalizeWhatsappNumber($from);
+        if ($recipient === null) {
+            return [
+                'ok' => false,
+                'reason' => 'invalid_recipient',
+            ];
+        }
+        if ($sender === null) {
+            return [
+                'ok' => false,
+                'reason' => 'invalid_sender',
+            ];
+        }
+
+        try {
+            $response = Http::withBasicAuth($sid, $token)
+                ->asForm()
+                ->post("https://api.twilio.com/2010-04-01/Accounts/{$sid}/Messages.json", [
+                    'To' => $recipient,
+                    'From' => $sender,
+                    'Body' => $message,
+                ]);
+        } catch (\Throwable $exception) {
+            return [
+                'ok' => false,
+                'reason' => 'http_exception',
+                'error' => $exception->getMessage(),
+            ];
+        }
+
+        if ($response->successful()) {
+            return [
+                'ok' => true,
+                'status' => $response->status(),
+                'sid' => $response->json('sid'),
+            ];
+        }
+
+        return [
+            'ok' => false,
+            'reason' => 'twilio_error',
+            'status' => $response->status(),
+            'code' => $response->json('code'),
+            'message' => $response->json('message'),
+            'more_info' => $response->json('more_info'),
+        ];
+    }
+
+    private function normalizeWhatsappNumber(string $value): ?string
+    {
+        $raw = preg_replace('/^whatsapp:/i', '', trim($value)) ?? '';
+        if ($raw === '') {
+            return null;
+        }
+
+        $digits = preg_replace('/\D+/', '', $raw) ?: '';
+        if (str_starts_with($digits, '00') && strlen($digits) > 2) {
+            $digits = substr($digits, 2);
+        }
+        if (strlen($digits) === 10) {
+            $digits = '1'.$digits;
+        }
+        if (! preg_match('/^[1-9]\d{7,14}$/', $digits)) {
+            return null;
+        }
+
+        return 'whatsapp:+'.$digits;
     }
 }

--- a/docs/audits/mlkpro-benchmark-2026-07-16/execution/PHASE_0_SECURITY_AND_BASELINE.md
+++ b/docs/audits/mlkpro-benchmark-2026-07-16/execution/PHASE_0_SECURITY_AND_BASELINE.md
@@ -1,7 +1,7 @@
 # Phase 0 — Sécurité et baseline
 
 - Dernière mise à jour : 2026-07-17
-- Statut : **jeton secondaire et canari SMS validés localement — autres canaris et gate externe incomplets**
+- Statut : **jeton secondaire, SMS et harnais des canaris validés localement — sender WhatsApp et gate externe incomplets**
 - Responsable d’exécution locale : Codex
 - Propriétaire exploitation : à nommer
 - Validateur produit : demandeur
@@ -83,7 +83,7 @@ Cette baseline doit être confirmée au début de la phase et enregistrée dans 
 
 ### MLK-IMP-P0-001 — Contenir l’exposition Twilio
 
-- Statut : **en validation — jeton secondaire et canari SMS validés localement ; autres canaris et promotion requis**
+- Statut : **en validation — jeton secondaire, canari SMS et harnais de contrôle validés localement ; sender WhatsApp, autres canaris et promotion requis**
 - Priorité : immédiate
 - Propriétaire attendu : administrateur Twilio / exploitation
 - But : rendre inutilisable tout jeton exposé et confirmer les communications avec un nouveau secret.

--- a/docs/audits/mlkpro-benchmark-2026-07-16/execution/README.md
+++ b/docs/audits/mlkpro-benchmark-2026-07-16/execution/README.md
@@ -1,7 +1,7 @@
 # Cockpit d’exécution contrôlée — amélioration MLK Pro
 
 - Dernière mise à jour : 2026-07-17
-- Statut global : **Phase 0 en cours — jeton secondaire et canari SMS validés localement, rotation non finalisée**
+- Statut global : **Phase 0 en cours — SMS et harnais des canaris validés localement ; aucun sender WhatsApp enregistré, rotation non finalisée**
 - Phase active autorisée : **Phase 0, canaris et inventaire des environnements ; promotion interdite avant validation complète**
 - Responsable d’exécution locale : Codex
 - Responsable exploitation : à nommer

--- a/docs/audits/mlkpro-benchmark-2026-07-16/execution/VALIDATION_LOG.md
+++ b/docs/audits/mlkpro-benchmark-2026-07-16/execution/VALIDATION_LOG.md
@@ -86,6 +86,27 @@ Dernière mise à jour : 2026-07-17
 - Promotion : non exécutée ; l’ancien jeton principal reste valide.
 - Verdict : **canari SMS réussi** ; rotation globale encore ouverte.
 
+## VALID-P0-001-HARNESS-2026-07-17 — Harnais des canaris Twilio restants
+
+- Ticket : `MLK-IMP-P0-001`.
+- Date : 2026-07-17.
+- Base livrée : `main` au commit `7b76232`, incluant la PR `#129` fusionnée.
+- Commit du lot : `b7efe04` sur `agent/twilio-canary-harness`.
+- Environnement : Windows local, PHP 8.4.23 et build Vite de production.
+- Changement contrôlé : ajout de `whatsapp:test`, diagnostic structuré du service WhatsApp, test du transport 2FA SMS avec repli email et test de campagne SMS limité à l’acteur connecté.
+- Protection des communications : toutes les requêtes Twilio des tests utilisent `Http::fake()` avec `Http::preventStrayRequests()` ; les notifications email utilisent `Notification::fake()` ; aucun SMS, WhatsApp ou email réel n’a été envoyé par ce lot.
+- Test rouge initial : les cinq scénarios WhatsApp échouaient comme prévu parce que `whatsapp:test` n’existait pas.
+- Tests ciblés du harnais : 16 réussis, 87 assertions.
+- Non-régression fonctionnelle Twilio, 2FA, réglages et campagnes : 99 réussis, 693 assertions.
+- Non-régression complète : 1 140 tests réussis, 12 071 assertions, durée 345,92 s.
+- Qualité : Pint réussi sur six fichiers ; PHPStan complet réussi sans erreur ; `git diff --check` réussi.
+- Frontend : build Vite réussi, 2 603 modules, durée 2 min 8 s.
+- Contrôle fournisseur en lecture seule : l’API officielle des senders WhatsApp a répondu HTTP 200, sans sender enregistré sur le compte ; la valeur locale configurée ne correspond donc pas à un sender WhatsApp actif. Aucun numéro ni identifiant de sender n’a été consigné.
+- Rollback : revert du commit `b7efe04` ; le contrat booléen historique de `WhatsappNotificationService::send()` reste compatible.
+- Canaris réels restants : activer un Sandbox ou enregistrer un sender WhatsApp, faire rejoindre le destinataire contrôlé, puis exécuter WhatsApp, 2FA SMS et campagne SMS avant promotion.
+- Promotion : non exécutée ; l’ancien jeton principal reste valide.
+- Verdict : **harnais local validé** ; envoi WhatsApp bloqué proprement par l’absence de sender, autres canaris et rotation globale toujours ouverts.
+
 ## Gate d’entrée Phase 0 — À compléter
 
 - ID : `GATE-P0-ENTRY`
@@ -107,7 +128,7 @@ Dernière mise à jour : 2026-07-17
 
 | Ticket | Statut | Responsable | Validateur | Commit/déploiement | Preuve | Verdict |
 |---|---|---|---|---|---|---|
-| MLK-IMP-P0-001 | En validation — secondaire local et SMS validés | Demandeur / Codex pour les contrôles | Demandeur | Local, base `d89ad55` | `CANARY-P0-001-SMS-2026-07-17` | WhatsApp, 2FA, campagne, promotion et rejet de l’ancien jeton requis |
+| MLK-IMP-P0-001 | En validation — secondaire, SMS et harnais validés | Demandeur / Codex pour les contrôles | Demandeur | Local, `b7efe04` | `VALID-P0-001-HARNESS-2026-07-17` | Sender WhatsApp, canaris réels, promotion et rejet de l’ancien jeton requis |
 | MLK-IMP-P0-002 | Pré-baseline enregistrée | Codex | Demandeur | Local, `d89ad55` | `PRECHECK-P0-2026-07-16` | Attente fermeture P0-001 |
 | MLK-IMP-P0-003 | À valider |  |  |  |  |  |
 | MLK-IMP-P0-004 | À valider |  |  |  |  |  |

--- a/routes/console.php
+++ b/routes/console.php
@@ -62,6 +62,7 @@ use App\Services\StripePlanPriceProvisioner;
 use App\Services\SupportAssignmentService;
 use App\Services\SupportSettingsService;
 use App\Services\UpcomingBillingReminderService;
+use App\Services\WhatsappNotificationService;
 use App\Services\WorkBillingService;
 use App\Support\LocalePreference;
 use App\Support\NotificationDispatcher;
@@ -890,6 +891,77 @@ Artisan::command('sms:test {to} {--message=}', function (SmsNotificationService 
 
     return 0;
 })->purpose('Send a test SMS using Twilio credentials');
+
+Artisan::command('whatsapp:test {to} {--message=}', function (WhatsappNotificationService $whatsappService): int {
+    $to = preg_replace('/^whatsapp:/i', '', trim((string) $this->argument('to'))) ?? '';
+    $message = trim((string) $this->option('message'));
+    $sid = trim((string) config('services.twilio.sid'));
+    $token = trim((string) config('services.twilio.token'));
+    $from = trim((string) config('services.twilio.whatsapp_from'));
+
+    if ($to === '') {
+        $this->error('Numero destinataire manquant.');
+
+        return 1;
+    }
+
+    if (preg_match('/^\d{10}$/', $to)) {
+        $to = '+1'.$to;
+    }
+
+    if (! preg_match('/^\+[1-9]\d{7,14}$/', $to)) {
+        $this->error('Numero invalide. Utilisez le format E.164, ex: +15145551234');
+
+        return 1;
+    }
+
+    if ($sid === '' || $token === '' || $from === '') {
+        $this->error('Configuration Twilio WhatsApp incomplete. Definissez TWILIO_SID, TWILIO_AUTH_TOKEN, TWILIO_WHATSAPP_FROM.');
+
+        return 1;
+    }
+
+    if ($message === '') {
+        $message = implode(' | ', [
+            'Test WhatsApp',
+            (string) config('app.name'),
+            now()->toDateTimeString(),
+        ]);
+    }
+
+    $this->line('Envoi du canari WhatsApp vers le destinataire controle...');
+    $result = $whatsappService->sendWithResult($to, $message);
+
+    if (! ($result['ok'] ?? false)) {
+        $reason = (string) ($result['reason'] ?? 'unknown');
+        $status = (string) ($result['status'] ?? '-');
+        $code = (string) ($result['code'] ?? '-');
+        $errorMessage = trim((string) ($result['message'] ?? $result['error'] ?? 'Unknown error'));
+        $moreInfo = trim((string) ($result['more_info'] ?? ''));
+
+        $this->error('Echec envoi WhatsApp.');
+        $this->line("reason={$reason} status={$status} code={$code}");
+        if ($errorMessage !== '') {
+            $this->line("message={$errorMessage}");
+        }
+        if ($moreInfo !== '') {
+            $this->line("more_info={$moreInfo}");
+        }
+
+        if ($reason === 'twilio_error' && $code === '63015') {
+            $this->line('Hint: le destinataire doit rejoindre le Sandbox WhatsApp Twilio avant le test.');
+        }
+        if ($reason === 'twilio_error' && $code === '63007') {
+            $this->line('Hint: TWILIO_WHATSAPP_FROM doit etre un expediteur WhatsApp Twilio actif.');
+        }
+
+        return 1;
+    }
+
+    $this->info('OK: message WhatsApp accepte par Twilio.');
+
+    return 0;
+})->purpose('Send a controlled WhatsApp test using Twilio credentials');
 
 Artisan::command('mailgun:test {to}
     {--from= : Override from address}

--- a/tests/Feature/Auth/TwoFactorServiceTest.php
+++ b/tests/Feature/Auth/TwoFactorServiceTest.php
@@ -1,0 +1,127 @@
+<?php
+
+use App\Models\User;
+use App\Notifications\TwoFactorCodeNotification;
+use App\Services\TwoFactorService;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Notification;
+
+beforeEach(function () {
+    Http::preventStrayRequests();
+    Notification::fake();
+
+    config()->set('services.twilio.sid', 'AC_TEST_ACCOUNT_SID');
+    config()->set('services.twilio.token', 'test-auth-token');
+    config()->set('services.twilio.from', '+15145550101');
+});
+
+function twoFactorServiceSmsUser(): User
+{
+    return User::factory()->create([
+        'locale' => 'fr',
+        'phone_number' => '+15145550123',
+        'two_factor_exempt' => false,
+        'two_factor_enabled' => false,
+        'two_factor_method' => TwoFactorService::METHOD_SMS,
+        'company_notification_settings' => [
+            'security' => [
+                'two_factor_sms' => true,
+            ],
+        ],
+    ]);
+}
+
+test('two factor service sends and persists a matching code by sms', function () {
+    Http::fake([
+        'https://api.twilio.com/*' => Http::response([
+            'sid' => 'SM_TEST_MESSAGE_SID',
+        ], 201),
+    ]);
+
+    $user = twoFactorServiceSmsUser();
+
+    $result = app(TwoFactorService::class)->sendCode(
+        $user,
+        force: true,
+        preferredMethod: TwoFactorService::METHOD_SMS,
+    );
+
+    $user->refresh();
+
+    expect($result)->toMatchArray([
+        'sent' => true,
+        'retry_after' => 0,
+        'method' => TwoFactorService::METHOD_SMS,
+    ])->and($user->two_factor_enabled)->toBeTrue()
+        ->and($user->two_factor_code)->not->toBeNull()
+        ->and($user->two_factor_expires_at)->not->toBeNull()
+        ->and($user->two_factor_last_sent_at)->not->toBeNull();
+
+    expect(
+        $user->two_factor_expires_at->equalTo(
+            $user->two_factor_last_sent_at
+                ->copy()
+                ->addMinutes(TwoFactorService::EXPIRY_MINUTES)
+        )
+    )->toBeTrue();
+
+    Http::assertSent(function (Request $request) use ($user): bool {
+        $data = $request->data();
+
+        if (preg_match('/\b(\d{6})\b/', (string) ($data['Body'] ?? ''), $matches) !== 1) {
+            return false;
+        }
+
+        return ($data['To'] ?? null) === '+15145550123'
+            && ($data['From'] ?? null) === '+15145550101'
+            && Hash::check($matches[1], $user->two_factor_code);
+    });
+
+    Http::assertSentCount(1);
+    Notification::assertNothingSent();
+});
+
+test('two factor service falls back to email when twilio rejects sms', function () {
+    Http::fake([
+        'https://api.twilio.com/*' => Http::response([
+            'code' => 20003,
+            'message' => 'Authentication rejected',
+        ], 401),
+    ]);
+
+    $user = twoFactorServiceSmsUser();
+
+    $result = app(TwoFactorService::class)->sendCode(
+        $user,
+        force: true,
+        preferredMethod: TwoFactorService::METHOD_SMS,
+    );
+
+    $user->refresh();
+
+    expect($result)->toMatchArray([
+        'sent' => true,
+        'retry_after' => 0,
+        'method' => TwoFactorService::METHOD_EMAIL,
+    ])->and($user->two_factor_enabled)->toBeTrue()
+        ->and($user->two_factor_code)->not->toBeNull();
+
+    Http::assertSentCount(1);
+
+    Notification::assertSentTo(
+        $user,
+        TwoFactorCodeNotification::class,
+        function (TwoFactorCodeNotification $notification, array $channels) use ($user): bool {
+            $code = $notification->toMail($user)->viewData['code'] ?? null;
+
+            return $channels === ['mail']
+                && is_string($code)
+                && preg_match('/^\d{6}$/', $code) === 1
+                && Hash::check($code, $user->two_factor_code);
+        }
+    );
+
+    Notification::assertSentToTimes($user, TwoFactorCodeNotification::class, 1);
+});

--- a/tests/Feature/CampaignsMarketingModuleTest.php
+++ b/tests/Feature/CampaignsMarketingModuleTest.php
@@ -2904,6 +2904,88 @@ test('campaign update accepts service offers when legacy product ids payload is 
         ->and((string) $campaign->offers->first()->offer_type)->toBe('service');
 });
 
+test('campaign sms test send targets only the actor without creating an audience run', function () {
+    Queue::fake();
+    Http::preventStrayRequests();
+
+    config()->set([
+        'services.twilio.sid' => 'AC_TEST_CAMPAIGN_SID',
+        'services.twilio.token' => 'test-campaign-token',
+        'services.twilio.from' => '+15145550101',
+    ]);
+
+    Http::fake([
+        'https://api.twilio.com/*' => Http::response([
+            'sid' => 'SM_CAMPAIGN_TEST',
+        ], 201),
+    ]);
+
+    $audienceResolver = \Mockery::mock(AudienceResolver::class);
+    $audienceResolver->shouldNotReceive('resolveForCampaign');
+    $this->app->instance(AudienceResolver::class, $audienceResolver);
+
+    $owner = marketingOwner([
+        'phone_number' => '+15145550103',
+    ]);
+    $actor = marketingTeamMember(
+        $owner,
+        ['campaigns.send'],
+        ['phone_number' => '+15145550102']
+    );
+    $customer = marketingCustomer($owner, [
+        'phone' => '+15145550199',
+    ]);
+
+    $campaign = Campaign::query()->create([
+        'user_id' => $owner->id,
+        'created_by_user_id' => $owner->id,
+        'updated_by_user_id' => $owner->id,
+        'name' => 'SMS test campaign',
+        'type' => Campaign::TYPE_PROMOTION,
+        'campaign_type' => Campaign::TYPE_PROMOTION,
+        'offer_mode' => Campaign::OFFER_MODE_PRODUCTS,
+        'status' => Campaign::STATUS_DRAFT,
+        'schedule_type' => Campaign::SCHEDULE_MANUAL,
+        'is_marketing' => true,
+    ]);
+
+    $campaign->channels()->create([
+        'channel' => Campaign::CHANNEL_SMS,
+        'is_enabled' => true,
+        'body_template' => 'Canari campagne SMS',
+    ]);
+
+    $response = $this->actingAs($actor)->postJson(
+        route('campaigns.test-send', $campaign),
+        ['channels' => [Campaign::CHANNEL_SMS]]
+    );
+
+    $response->assertOk()
+        ->assertJsonCount(1, 'results')
+        ->assertJsonPath('results.0.channel', Campaign::CHANNEL_SMS)
+        ->assertJsonPath('results.0.ok', true)
+        ->assertJsonPath('results.0.provider_message_id', 'SM_CAMPAIGN_TEST');
+
+    Http::assertSent(function (HttpClientRequest $request) use ($owner, $actor, $customer): bool {
+        $data = $request->data();
+
+        return $request->method() === 'POST'
+            && $request->url() === 'https://api.twilio.com/2010-04-01/Accounts/AC_TEST_CAMPAIGN_SID/Messages.json'
+            && ($data['To'] ?? null) === $actor->phone_number
+            && ($data['To'] ?? null) !== $owner->phone_number
+            && ($data['To'] ?? null) !== $customer->phone
+            && ($data['From'] ?? null) === '+15145550101'
+            && ($data['Body'] ?? null) === 'Canari campagne SMS';
+    });
+    Http::assertSentCount(1);
+
+    Queue::assertNothingPushed();
+
+    expect(CampaignRun::query()->exists())->toBeFalse()
+        ->and(CampaignRecipient::query()->exists())->toBeFalse()
+        ->and($campaign->audience()->exists())->toBeFalse();
+});
+
 test('sending workflow queues dispatch and recipient jobs', function () {
     Queue::fake();
 

--- a/tests/Feature/WhatsappTestCommandTest.php
+++ b/tests/Feature/WhatsappTestCommandTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    Http::preventStrayRequests();
+
+    config()->set('services.twilio.sid', 'AC_TEST_ACCOUNT_SID');
+    config()->set('services.twilio.token', 'test-auth-token');
+    config()->set('services.twilio.whatsapp_from', '+15145550101');
+});
+
+test('whatsapp test command normalizes a ten digit north american recipient', function () {
+    Http::fake([
+        'https://api.twilio.com/*' => Http::response(['sid' => 'SM_TEST_MESSAGE_SID'], 201),
+    ]);
+
+    $this->artisan('whatsapp:test', [
+        'to' => '5145550102',
+        '--message' => 'Rotation canary',
+    ])->assertExitCode(0);
+
+    Http::assertSent(fn (Request $request): bool => $request->data() === [
+        'To' => 'whatsapp:+15145550102',
+        'From' => 'whatsapp:+15145550101',
+        'Body' => 'Rotation canary',
+    ]);
+    Http::assertSentCount(1);
+});
+
+test('whatsapp test command preserves an international e164 recipient', function () {
+    Http::fake([
+        'https://api.twilio.com/*' => Http::response(['sid' => 'SM_TEST_MESSAGE_SID'], 201),
+    ]);
+
+    $this->artisan('whatsapp:test', [
+        'to' => '+442079460123',
+        '--message' => 'International canary',
+    ])->assertExitCode(0);
+
+    Http::assertSent(fn (Request $request): bool => $request->data()['To'] === 'whatsapp:+442079460123');
+    Http::assertSentCount(1);
+});
+
+test('whatsapp test command rejects an invalid recipient without sending', function () {
+    Http::fake();
+
+    $this->artisan('whatsapp:test', [
+        'to' => '51455',
+        '--message' => 'Invalid canary',
+    ])
+        ->expectsOutputToContain('Numero invalide')
+        ->assertExitCode(1);
+
+    Http::assertNothingSent();
+});
+
+test('whatsapp test command refuses incomplete configuration without sending', function () {
+    config()->set('services.twilio.whatsapp_from');
+    Http::fake();
+
+    $this->artisan('whatsapp:test', [
+        'to' => '+15145550102',
+        '--message' => 'Missing configuration canary',
+    ])
+        ->expectsOutputToContain('Configuration Twilio WhatsApp incomplete')
+        ->assertExitCode(1);
+
+    Http::assertNothingSent();
+});
+
+test('whatsapp test command reports when a sandbox recipient has not joined', function () {
+    Http::fake([
+        'https://api.twilio.com/*' => Http::response([
+            'code' => 63015,
+            'message' => 'Channel Sandbox can only send messages to phone numbers that have joined the Sandbox',
+            'more_info' => 'https://www.twilio.com/docs/errors/63015',
+        ], 400),
+    ]);
+
+    $this->artisan('whatsapp:test', [
+        'to' => '5145550102',
+        '--message' => 'Rejected canary',
+    ])
+        ->expectsOutputToContain('reason=twilio_error status=400 code=63015')
+        ->expectsOutputToContain('rejoindre le Sandbox WhatsApp')
+        ->assertExitCode(1);
+
+    Http::assertSentCount(1);
+});

--- a/tests/Unit/Services/TwilioNotificationServicesTest.php
+++ b/tests/Unit/Services/TwilioNotificationServicesTest.php
@@ -144,16 +144,39 @@ test('whatsapp normalizes prefixes and authenticates', function () {
     Http::assertSentCount(1);
 });
 
-test('whatsapp returns false when the provider rejects authentication', function () {
+test('whatsapp exposes provider rejection details', function () {
     config()->set('services.twilio.sid', 'AC_TEST_ACCOUNT_SID');
     config()->set('services.twilio.token', 'rejected-test-token');
     config()->set('services.twilio.whatsapp_from', '+15145550101');
 
     Http::fake([
-        'https://api.twilio.com/*' => Http::response(['code' => 20003], 401),
+        'https://api.twilio.com/*' => Http::response([
+            'code' => 20003,
+            'message' => 'Authentication rejected',
+        ], 401),
     ]);
 
-    $sent = app(WhatsappNotificationService::class)->send('+15145550102', 'Rotation canary');
+    $result = app(WhatsappNotificationService::class)->sendWithResult('+15145550102', 'Rotation canary');
 
-    expect($sent)->toBeFalse();
+    expect($result)->toMatchArray([
+        'ok' => false,
+        'reason' => 'twilio_error',
+        'status' => 401,
+        'code' => 20003,
+    ]);
+});
+
+test('whatsapp maps a connection failure', function () {
+    config()->set('services.twilio.sid', 'AC_TEST_ACCOUNT_SID');
+    config()->set('services.twilio.token', 'test-token');
+    config()->set('services.twilio.whatsapp_from', '+15145550101');
+
+    Http::fake(fn () => throw new ConnectionException('Simulated connection failure'));
+
+    $result = app(WhatsappNotificationService::class)->sendWithResult('+15145550102', 'Rotation canary');
+
+    expect($result)->toMatchArray([
+        'ok' => false,
+        'reason' => 'http_exception',
+    ]);
 });


### PR DESCRIPTION
## Summary

- add a guarded `whatsapp:test` command with E.164 normalization and actionable Twilio diagnostics
- expose structured WhatsApp delivery results while preserving the existing boolean `send()` contract
- cover successful SMS 2FA delivery and its email fallback
- prove campaign SMS test-send targets only the authenticated actor and creates no audience run, recipient, or queued job
- record the provider precheck and validation evidence in the Phase 0 cockpit

## Why

The remaining Twilio rotation canaries had no safe operator command for WhatsApp and lacked direct coverage for the 2FA SMS transport and campaign test-send boundary. A read-only Twilio Senders API check also confirmed that the account currently has no registered WhatsApp sender, so a real canary must wait for a Sandbox activation/join or a registered sender.

Official references:
- [Twilio WhatsApp Sandbox](https://www.twilio.com/docs/whatsapp/sandbox)
- [Twilio WhatsApp Senders API](https://www.twilio.com/docs/whatsapp/api/senders)

## Impact and safety

- existing application callers keep the same boolean WhatsApp service contract
- invalid recipients and senders fail before network traffic
- network and provider failures now return structured diagnostics
- no real SMS, WhatsApp message, or email was sent by automated tests
- all Twilio HTTP calls are faked and stray requests are blocked
- no production secret or real recipient is present in the diff

## Validation

- targeted canary tests: 16 passed, 87 assertions
- Twilio/2FA/settings/campaign regression: 99 passed, 693 assertions
- full PHP suite: 1,140 passed, 12,071 assertions
- PHPStan: no errors
- Laravel Pint: 6 files pass
- Vite production build: 2,603 modules
- `git diff --check`: pass
- staged secret scan: zero realistic Twilio SID patterns and zero Twilio credential assignments

## Remaining operational gate

Before token promotion: activate a WhatsApp Sandbox or register a sender, join it from the controlled recipient, then complete real WhatsApp, 2FA SMS, and campaign SMS canaries.